### PR TITLE
Make github workflow build and publish a runnable restape image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,88 @@
+##############################
+## Java
+##############################
+.mtj.tmp/
+*.class
+*.jar
+*.war
+*.ear
+*.nar
+hs_err_pid*
+
+##############################
+## Maven
+##############################
+target/
+pom.xml.tag
+pom.xml.releaseBackup
+pom.xml.versionsBackup
+pom.xml.next
+pom.xml.bak
+release.properties
+dependency-reduced-pom.xml
+buildNumber.properties
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.jar
+
+##############################
+## Gradle
+##############################
+bin/
+/bin/
+build/
+.gradle
+.gradletasknamecache
+gradle-app.setting
+!gradle-wrapper.jar
+
+##############################
+## IntelliJ
+##############################
+out/
+.idea/
+.idea_modules/
+*.iml
+*.ipr
+*.iws
+
+##############################
+## Eclipse
+##############################
+.settings/
+/.settings/
+bin/
+tmp/
+.metadata
+.classpath
+.project
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.loadpath
+.factorypath
+
+##############################
+## NetBeans
+##############################
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+
+##############################
+## Visual Studio Code
+##############################
+.vscode/
+
+##############################
+## OS X
+##############################
+.DS_Store
+/lib/
+/apeOutputs/
+/https:/

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: "monthly"
+      day: "monday"

--- a/.github/workflows/clean-containers.yaml
+++ b/.github/workflows/clean-containers.yaml
@@ -1,0 +1,33 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: ghcr actions
+
+on:
+  schedule:
+    - cron: "21 21 * * *"
+
+jobs:
+  clean-ghcr:
+    name: Delete old unused container images
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: downcase REPO name
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+      - name: Delete 'PR' containers older than a week
+        uses: snok/container-retention-policy@v2.1.1
+        with:
+          image-names: ${{ env.REGISTRY }}/${{ env.REPO }}
+          filter-tags: sha-*,sha256:*
+          skip-tags: latest
+          cut-off: A week ago UTC
+          account-type: org
+          org-name: ${{ github.repository_owner }}
+          keep-at-least: 1
+          token: ${{ secrets.GH_REPO_TOKEN }}
+          timestamp-to-use: updated_at

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,50 @@
+name: Build and Publish
+
+on: [push]
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: downcase REPO name
+        run: |
+          echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=sha,enable=true,priority=100,prefix=sha-,suffix=,format=short
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=${{ github.event.repository.clone_url }}
+            org.opencontainers.image.created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,21 @@
-FROM eclipse-temurin:17-jdk-jammy
+FROM maven:3-eclipse-temurin-17 AS builder
+
 WORKDIR /app
-COPY restape-0.2.4.jar /app
-ENTRYPOINT ["java", "-jar", "restape-0.2.4.jar"]
+
+COPY pom.xml pom.xml
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -f pom.xml dependency:resolve
+
+COPY . .
+
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -f pom.xml clean package
+
+
+FROM eclipse-temurin:17-jre-jammy 
+
+WORKDIR /app
+COPY --from=builder /app/target/*.jar /app/runner.jar
+
+ENTRYPOINT ["java", "-jar", "/app/runner.jar"]


### PR DESCRIPTION
### Description

It's easier to run restape without having to build it locally. This change creates a GitHub workflow and makes changes to the Dockerfile so that the workflow builds an packages restape into a docker image and pushes it to github registry. Some configuration might still be necessary in the repository or github organization to make the images publicly available.

This PR also comes with a file to avoid copying unnecessary files to the docker build context, dependabot checks, and a workflow to remove old images (not the tagged ones).