### PR TITLE
FIx citation issue

### DIFF
--- a/src/main/java/nl/esciencecenter/externalAPIs/OpenEBenchBenchmarkProcessor.java
+++ b/src/main/java/nl/esciencecenter/externalAPIs/OpenEBenchBenchmarkProcessor.java
@@ -154,7 +154,7 @@ public class OpenEBenchBenchmarkProcessor {
                 e.printStackTrace();
                 // set case for each license type
                 biotoolsEntryBenchmark.setDesirabilityValue(0);
-                biotoolsEntryBenchmark.setValue("Unknown");
+                biotoolsEntryBenchmark.setValue("0");
                 biotoolsEntryBenchmark.setDescription("Unknown");
                 biotoolsEntries.add(biotoolsEntryBenchmark);
             }


### PR DESCRIPTION
We encountered an issue where if a tool isn't listed in bio.tools, its citation count is labeled as "Unknown." Since this can't be added to create a sum because it's not an integer, I've converted these instances to 0 and set the description to "unknown."