### PR TITLE
Expose the functionality to suppress the creation of non-executable CWL and snakemake files.

### DIFF
--- a/src/main/java/nl/esciencecenter/controller/dto/WorkflowsZip.java
+++ b/src/main/java/nl/esciencecenter/controller/dto/WorkflowsZip.java
@@ -1,5 +1,6 @@
 package nl.esciencecenter.controller.dto;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -82,15 +83,24 @@ public class WorkflowsZip {
     }
 
     /**
-     * Get the paths to the CWL, Snakemake and the SVG files.
+     * Get the paths to the existing CWL, Snakemake and the SVG files.
      * 
-     * @return List of paths to the CWL, Snakemake and the SVG files.
+     * @return List of paths to the existing CWL, Snakemake and the SVG files.
      */
     public List<Path> getAllPaths() {
         List<Path> paths = new ArrayList<>();
         for (String fileName : workflows) {
-            paths.add(RestApeUtils.calculatePath(runID, "CWL", fileName));
-            paths.add(RestApeUtils.calculatePath(runID, "Snakemake", fileName.replace(".cwl", ".smk")));
+
+            Path cwlPath = RestApeUtils.calculatePath(runID, "CWL", fileName);
+            if(Files.exists(cwlPath)) {
+                paths.add(cwlPath);
+            }
+
+            Path smkPath = RestApeUtils.calculatePath(runID, "Snakemake", fileName.replace(".cwl", ".smk"));
+            if(Files.exists(smkPath)) {
+                paths.add(smkPath);
+            }
+
             paths.add(RestApeUtils.calculatePath(runID, "Figures", fileName.replace(".cwl", ".svg")));
         }
         return paths;

--- a/src/main/java/nl/esciencecenter/restape/APEWorkflowMetadata.java
+++ b/src/main/java/nl/esciencecenter/restape/APEWorkflowMetadata.java
@@ -56,14 +56,14 @@ public class APEWorkflowMetadata {
 
         String fileName = sol.getFileName();
 
-        Path cwlPath = RestApeUtils.calculatePath(runID, "CWL", fileName);
+        Path cwlPath = RestApeUtils.calculatePath(runID, "CWL", fileName + ".cwl");
         if(Files.notExists(cwlPath)) {
             this.cwlName = "";
         } else {
             this.cwlName = fileName + ".cwl";
         }
 
-        Path smkPath = RestApeUtils.calculatePath(runID, "Snakemake", fileName);
+        Path smkPath = RestApeUtils.calculatePath(runID, "Snakemake", fileName + ".smk");
         if(Files.notExists(smkPath)) {
             this.snakemakeName = "";
         } else {

--- a/src/main/java/nl/esciencecenter/restape/APEWorkflowMetadata.java
+++ b/src/main/java/nl/esciencecenter/restape/APEWorkflowMetadata.java
@@ -8,6 +8,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import nl.uu.cs.ape.solver.solutionStructure.SolutionWorkflow;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 /**
  * The {@link APEWorkflowMetadata} class represents metadata for a workflow solution from the APE solver.
  * This class encapsulates the details and metadata of a workflow solution,
@@ -50,11 +53,26 @@ public class APEWorkflowMetadata {
         this.description = sol.getDescription();
         this.workflowLength = sol.getSolutionLength();
         this.runId = runID;
-        this.cwlName = sol.getFileName() + ".cwl";
-        this.snakemakeName = sol.getFileName() + ".smk";
-        this.figureName = sol.getFileName();
+
+        String fileName = sol.getFileName();
+
+        Path cwlPath = RestApeUtils.calculatePath(runID, "CWL", fileName);
+        if(Files.notExists(cwlPath)) {
+            this.cwlName = "";
+        } else {
+            this.cwlName = fileName + ".cwl";
+        }
+
+        Path smkPath = RestApeUtils.calculatePath(runID, "Snakemake", fileName);
+        if(Files.notExists(smkPath)) {
+            this.snakemakeName = "";
+        } else {
+            this.snakemakeName = fileName + ".smk";
+        }
+
+        this.figureName = fileName;
         if (benchmark) {
-            this.benchmarkFile = sol.getFileName() + ".json";
+            this.benchmarkFile = fileName + ".json";
         }
     }
 

--- a/src/main/java/nl/esciencecenter/restape/ApeAPI.java
+++ b/src/main/java/nl/esciencecenter/restape/ApeAPI.java
@@ -246,11 +246,27 @@ public class ApeAPI {
         // Define the synthesis run ID
         String runID = RestApeUtils.generateRunID(configJson.toString());
 
-        SolutionsList candidateSolutions = executeSynthesis(configJson, runID);
+        String solutionPath = RestApeUtils.createDirectory(runID);
+
+        APE apeFramework = new APE(configJson);
+
+        APERunConfig runConfig = new APERunConfig(configJson, apeFramework.getDomainSetup());
+
+        runConfig.setSolutionPath(solutionPath);
+        int maxSol = runConfig.getMaxNoSolutions();
+        runConfig.setNoCWL(maxSol);
+        runConfig.setNoSnakemake(maxSol);
+        runConfig.setNoGraphs(maxSol);
+        runConfig.setDebugMode(true);
+
+        bool createPartialScripts = runConfig.getCreatePartialScripts();
+
+        // run the synthesis and retrieve the solutions
+        SolutionsList candidateSolutions = apeFramework.runSynthesis(runConfig);
 
         // Write solutions (as CWL and Snakemake files and figures) to the file system.
-        APE.writeCWLWorkflows(candidateSolutions, true);
-        APE.writeSnakemakeWorkflows(candidateSolutions, true);
+        APE.writeCWLWorkflows(candidateSolutions, createPartialScripts);
+        APE.writeSnakemakeWorkflows(candidateSolutions, createPartialScripts);
         APE.writeTavernaDesignGraphs(candidateSolutions, Format.SVG);
         APE.writeTavernaDesignGraphs(candidateSolutions, Format.PNG);
 

--- a/src/main/java/nl/esciencecenter/restape/ApeAPI.java
+++ b/src/main/java/nl/esciencecenter/restape/ApeAPI.java
@@ -259,7 +259,7 @@ public class ApeAPI {
         runConfig.setNoGraphs(maxSol);
         runConfig.setDebugMode(true);
 
-        bool createPartialScripts = runConfig.getCreatePartialScripts();
+        boolean createPartialScripts = runConfig.getCreatePartialScripts();
 
         // run the synthesis and retrieve the solutions
         SolutionsList candidateSolutions = apeFramework.runSynthesis(runConfig);


### PR DESCRIPTION
## Pull Request Overview
<!-- Briefly describe what this PR does (e.g., bug fix, feature addition, etc.). -->

This PR uses the functionality from the APE backend to exclude "partial" scripts creation. If provided by the frontend,
the option `create_partial_scripts` is used by RestAPE and generation of CWL and Snakemake files for which the tool annotations are lacking the instructions/code to execute is skipped, if  `create_partial_scripts` is set to false.

## Related Issue
<!-- Link the related issue using the format `#issue_number`. -->

None.

## Changes Introduced
<!-- List the key changes made in this PR. -->

## How Has This Been Tested?
<!-- Briefly describe how you tested your changes. -->

## Checklist

- [ ] I have referenced a related issue.
- [ ] I have followed the project’s style guidelines.
- [ ] My changes include tests, if applicable.
- [x] All tests pass locally.
- [x] I have added myself to the CITATION.cff file, if not already present.
